### PR TITLE
Half way down to the authorization part

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,20 @@ limitations under the License.
     <failOnMissingWebXml>false</failOnMissingWebXml>
   </properties>
 
+  <!-- Google API Client for grouping dependencies and setting version -->
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>libraries-bom</artifactId>
+        <version>1.2.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+       </dependency>
+     </dependencies>
+  </dependencyManagement>
+  <!-- -->
+
   <dependencies>
 
     <dependency>
@@ -67,6 +81,36 @@ limitations under the License.
         <artifactId>commons-validator</artifactId>
         <version>1.4.0</version>
     </dependency>
+
+    <!-- Google API Client -->
+    <dependency>
+      <groupId>com.google.http-client</groupId>
+      <artifactId>google-http-client</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.http-client</groupId>
+      <artifactId>google-http-client-appengine</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.http-client</groupId>
+      <artifactId>google-http-client-jackson2</artifactId>
+    </dependency>
+    <!-- -->
+
+    <dependency>
+      <groupId>com.google.oauth-client</groupId>
+      <artifactId>google-oauth-client-jetty</artifactId>
+      <version>1.23.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.apis</groupId>
+      <artifactId>google-api-services-calendar</artifactId>
+      <version>v3-rev305-1.23.0</version>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -99,14 +99,6 @@ limitations under the License.
     </dependency>
     <!-- -->
 
-    <!--
-    <dependency>
-      <groupId>com.google.oauth-client</groupId>
-      <artifactId>google-oauth-client-jetty</artifactId>
-      <version>1.23.0</version>
-    </dependency>
-    -->
-
     <dependency>
       <groupId>com.google.apis</groupId>
       <artifactId>google-api-services-calendar</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -99,11 +99,13 @@ limitations under the License.
     </dependency>
     <!-- -->
 
+    <!--
     <dependency>
       <groupId>com.google.oauth-client</groupId>
       <artifactId>google-oauth-client-jetty</artifactId>
       <version>1.23.0</version>
     </dependency>
+    -->
 
     <dependency>
       <groupId>com.google.apis</groupId>

--- a/src/main/java/com/google/codeu/servlets/CalendarServlet.java
+++ b/src/main/java/com/google/codeu/servlets/CalendarServlet.java
@@ -1,0 +1,77 @@
+package com.google.codeu.servlets;
+
+import com.google.api.client.http.HttpRequestInitializer;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.client.extensions.appengine.http.UrlFetchTransport;
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.util.DateTime;
+import com.google.api.services.calendar.Calendar;
+import com.google.api.services.calendar.model.Event;    //Different from Calendar.Event which is a request
+import com.google.api.services.calendar.model.Events;
+import com.google.appengine.api.users.UserServiceFactory;
+
+import java.io.IOException;
+import java.io.FileNotFoundException;
+import java.security.GeneralSecurityException;
+import java.util.List;
+
+import com.google.gson.Gson;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import com.google.codeu.servlets.LoginServlet;
+
+@WebServlet("/calendar")
+public class CalendarServlet extends HttpServlet {
+  private static final String APPLICATION_NAME = "Google Calendar API Java Quickstart";
+  private static final JsonFactory JSON_FACTORY = JacksonFactory.getDefaultInstance();
+  private static final HttpTransport HTTP_TRANSPORT = new UrlFetchTransport();
+  private Calendar service = null;
+  private LoginServlet Login = null;
+  private String userId = null;
+
+  public CalendarServlet() throws IOException, FileNotFoundException{
+    Login = new LoginServlet();
+    userId = UserServiceFactory.getUserService().getCurrentUser().getUserId();
+    service = Login.getCalendar(userId);
+  }
+
+  @Override
+  public void doGet(HttpServletRequest request, HttpServletResponse response) 
+    throws IOException, FileNotFoundException{
+    if (UserServiceFactory.getUserService().isUserLoggedIn() == false){
+      response.sendRedirect("/login");
+      return;
+    }
+
+    if( Login.isAuthorized(userId) == false){
+      response.sendRedirect("/login");
+      return;
+    }
+
+    //List<Event> items = null;
+    // Build a new authorized API client service.
+
+    // List the next 10 events from the primary calendar.
+    DateTime now = new DateTime(System.currentTimeMillis());
+    if(service == null) System.out.println("angry bird");
+    Events events = service.events().list("primary")
+        .setMaxResults(10)
+        .setTimeMin(now)
+        .setOrderBy("startTime")
+        .setSingleEvents(true)
+        .execute();
+      //items = events.getItems();
+
+    response.setContentType("application/json");
+
+    Gson gson = new Gson();
+    //String json = gson.toJson(items);
+
+    response.getOutputStream().println(events.toString());
+
+  }
+}

--- a/src/main/java/com/google/codeu/servlets/CalendarServlet.java
+++ b/src/main/java/com/google/codeu/servlets/CalendarServlet.java
@@ -23,7 +23,7 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import com.google.codeu.servlets.LoginServlet;
+import com.google.codeu.servlets.CredentialServlet;
 
 @WebServlet("/calendar")
 public class CalendarServlet extends HttpServlet {
@@ -31,7 +31,7 @@ public class CalendarServlet extends HttpServlet {
   private static final JsonFactory JSON_FACTORY = JacksonFactory.getDefaultInstance();
   private static final HttpTransport HTTP_TRANSPORT = new UrlFetchTransport();
   private Calendar service = null;
-  private LoginServlet Login = null;
+  private CredentialServlet credentialServlet = new CredentialServlet();
   private String userId = null;
 
   @Override
@@ -42,15 +42,19 @@ public class CalendarServlet extends HttpServlet {
       return;
     }
 
-    Login = new LoginServlet();
     userId = UserServiceFactory.getUserService().getCurrentUser().getUserId();
 
-    if( userId != null && Login.isAuthorized(userId) == false){
+    if( userId == null ){
       response.sendRedirect("/login");
       return;
     }
 
-    service = Login.getCalendar(userId);
+    if( credentialServlet.isAuthorized(userId) == false){
+      response.sendRedirect("/credential");
+      return;
+    }
+
+    service = credentialServlet.getCalendar(userId);
 
     //List<Event> items = null;
     // Build a new authorized API client service.

--- a/src/main/java/com/google/codeu/servlets/CalendarServlet.java
+++ b/src/main/java/com/google/codeu/servlets/CalendarServlet.java
@@ -75,6 +75,7 @@ public class CalendarServlet extends HttpServlet {
         return;
       }catch(javax.servlet.ServletException e){
         System.err.println( "Calendar forward failed: " + e);
+        return;
       }
     }
 
@@ -85,7 +86,10 @@ public class CalendarServlet extends HttpServlet {
 
     // List the next 10 events from the primary calendar.
     DateTime now = new DateTime(System.currentTimeMillis());
-    if(service == null) System.out.println("angry bird");
+    if(service == null){
+      System.err.println("Calendar Service is null");
+      return;
+    }
     Events events;
     try{
       events = service.events().list("primary")

--- a/src/main/java/com/google/codeu/servlets/CalendarServlet.java
+++ b/src/main/java/com/google/codeu/servlets/CalendarServlet.java
@@ -1,6 +1,24 @@
+/*
+ * Copyright 2019 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Usage:
+ *   - Redirect to this page to get the data of one's next 10 events.
+ *   - Future features: Options through GET parameters.
+ */
 package com.google.codeu.servlets;
 
-import com.google.api.client.http.HttpRequestInitializer;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.client.extensions.appengine.http.UrlFetchTransport;
@@ -14,7 +32,6 @@ import com.google.appengine.api.users.UserServiceFactory;
 import java.io.IOException;
 import java.io.FileNotFoundException;
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
-import java.security.GeneralSecurityException;
 import java.util.List;
 
 import com.google.gson.Gson;
@@ -22,6 +39,7 @@ import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.servlet.RequestDispatcher;
 
 import com.google.codeu.servlets.CredentialServlet;
 
@@ -50,8 +68,14 @@ public class CalendarServlet extends HttpServlet {
     }
 
     if( credentialServlet.isAuthorized(userId) == false){
-      response.sendRedirect("/credential");
-      return;
+      try{
+        RequestDispatcher dispatcher = getServletContext().getRequestDispatcher("/credential");
+        request.setAttribute("from", "/calendar");
+        dispatcher.forward(request, response);
+        return;
+      }catch(javax.servlet.ServletException e){
+        System.err.println( "Calendar forward failed: " + e);
+      }
     }
 
     service = credentialServlet.getCalendar(userId);

--- a/src/main/java/com/google/codeu/servlets/CredentialServlet.java
+++ b/src/main/java/com/google/codeu/servlets/CredentialServlet.java
@@ -76,9 +76,10 @@ public class CredentialServlet extends HttpServlet {
     List<String> SCOPES = Collections.singletonList(CalendarScopes.CALENDAR);
 
     // Load client secrets.
-    InputStream in = LoginServlet.class.getResourceAsStream(CREDENTIALS_FILE_PATH);
+    InputStream in = CredentialServlet.class.getResourceAsStream(CREDENTIALS_FILE_PATH);
     if (in == null) {
-      throw new FileNotFoundException("Resource not found: " + CREDENTIALS_FILE_PATH);
+      //throw new FileNotFoundException("Resource not found: " + CREDENTIALS_FILE_PATH);
+      System.err.println("Resource not found: " + CREDENTIALS_FILE_PATH);
     }
     try{
       //GoogleCredential credential = GoogleCredential.fromStream(in).createScoped(SCOPES); //for service account with service account keys
@@ -93,7 +94,7 @@ public class CredentialServlet extends HttpServlet {
             String userId = userService.getCurrentUser().getUserId();
             System.out.println("User "+ userId +": OnCredentialCreated" );
             if( tokenResponse.getRefreshToken() == null ){
-              System.err.println( "OnCredentialCreated: tokenResponse is null");
+              System.err.println( "OnCredentialCreated: refreshToken is null");
               return;
             }
             /*  To maintain the tokens in DATA_STORE_FACTORY. The reason to keep this part is for being as reference once we needed it.
@@ -105,9 +106,9 @@ public class CredentialServlet extends HttpServlet {
           public void onTokenResponse(Credential credential, TokenResponse tokenResponse) throws IOException {
             UserService userService = UserServiceFactory.getUserService();
             String userId = userService.getCurrentUser().getUserId();
-            System.out.println("User "+ userId +": OnCredentialCreated" );
+            System.out.println("User "+ userId +": OnTokenRefreshed" );
             if( tokenResponse.getRefreshToken() == null ){
-              System.err.println( "OnCredentialCreated: tokenResponse is null");
+              System.err.println( "OnTokenRefreshed: refreshToken is null");
               return;
             }
           }
@@ -137,10 +138,12 @@ public class CredentialServlet extends HttpServlet {
     /*
       Record the previous url
     */
+    /*
     if(DATA_STORE_FACTORY.getDataStore(userId).get("referer") == null ){
       DATA_STORE_FACTORY.getDataStore(userId).set("referer", request.getHeader("referer"));
       System.out.println("First enter Credential with referer = " + request.getHeader("referer"));
     }
+    */
 
     // If the user has already authorized, redirect to their page
     if( isAuthorized(userId) == false ){
@@ -170,10 +173,13 @@ public class CredentialServlet extends HttpServlet {
     }
 
     // When using response.sendRedirect, saving(?) somethings like response.getOutputStream().println(json) will make a bug like it has been committed.
+    /*
     String referURL = DATA_STORE_FACTORY.getDataStore(userId).get("referer");
     DATA_STORE_FACTORY.getDataStore(userId).set("referer", null);
     System.out.println("Leaving from Credential to referer = " + referURL);
     response.sendRedirect(referURL);  
+    */
+    response.sendRedirect("/index.html");  
   }
 
   /*

--- a/src/main/java/com/google/codeu/servlets/LoginServlet.java
+++ b/src/main/java/com/google/codeu/servlets/LoginServlet.java
@@ -50,82 +50,17 @@ import com.google.api.client.auth.oauth2.TokenErrorResponse;
 import com.google.api.client.auth.oauth2.TokenResponseException;
 import com.google.api.client.auth.oauth2.CredentialRefreshListener;
 import com.google.api.client.auth.oauth2.Credential;
-import com.google.api.client.util.Clock;
 
 import com.google.api.client.googleapis.auth.oauth2.GoogleClientSecrets;
 
-
 import com.google.api.services.calendar.Calendar;
 
+import com.google.codeu.servlets.CredentialServlet;
 /**
  * Redirects the user to the Google login page or their page if they're already logged in.
  */
 @WebServlet("/login")
 public class LoginServlet extends HttpServlet {
-
-  private static final String CREDENTIALS_FILE_PATH = "/client_secret_Calendar_Events.json";
-  private static final AppEngineDataStoreFactory DATA_STORE_FACTORY = AppEngineDataStoreFactory.getDefaultInstance();//Not sure about whether it's global version.
-  private static final HttpTransport HTTP_TRANSPORT = new UrlFetchTransport();
-  private static final JsonFactory JSON_FACTORY = JacksonFactory.getDefaultInstance(); //JsonFactory is an abstract class, so here needs a subclass for it.
-
-  //The flow is the overall class for google authorization classes and methods.
-  private static GoogleAuthorizationCodeFlow flow = null; 
-
-  static{
-    List<String> SCOPES = Collections.singletonList(CalendarScopes.CALENDAR);
-
-    // Load client secrets.
-    InputStream in = LoginServlet.class.getResourceAsStream(CREDENTIALS_FILE_PATH);
-    //GoogleCredential credential = GoogleCredential.fromStream(in).createScoped(SCOPES); //for service account with service account keys
-    if (in == null) {
-      //throw new FileNotFoundException("Resource not found: " + CREDENTIALS_FILE_PATH);
-      System.err.println( "Resource not found: " + CREDENTIALS_FILE_PATH );
-      System.exit(-1);
-    }
-    try{
-      GoogleClientSecrets clientSecrets = GoogleClientSecrets.load(JSON_FACTORY, new InputStreamReader(in)); //for oauth2 with client id file
-
-      flow = new GoogleAuthorizationCodeFlow.Builder( HTTP_TRANSPORT, JSON_FACTORY, clientSecrets, SCOPES)
-        .setDataStoreFactory( DATA_STORE_FACTORY )
-        .setCredentialCreatedListener(new GoogleAuthorizationCodeFlow.CredentialCreatedListener() {
-          @Override
-          public void onCredentialCreated(Credential credential, TokenResponse tokenResponse) throws IOException {
-          System.out.println("OnCreated: refresh_token = " + tokenResponse.getRefreshToken() );
-            if( tokenResponse.getRefreshToken() == null ){
-              System.err.println( "tokenResponse is null");
-              return;
-            }
-            UserService userService = UserServiceFactory.getUserService();
-            String userId = userService.getCurrentUser().getUserId();
-            DATA_STORE_FACTORY.getDataStore("user").set(userId+"_token", tokenResponse.getRefreshToken());
-          }
-        }).addRefreshListener(new CredentialRefreshListener() {
-          @Override
-          public void onTokenResponse(Credential credential, TokenResponse tokenResponse) throws IOException {
-          System.out.println("OnRefreshed: refresh_token = " + tokenResponse );
-          System.out.println( "Credential from flow:\n\tRefreshToken = " + credential.getRefreshToken()
-              + "\n\tExpireTime = " + credential.getExpirationTimeMilliseconds());
-            if( tokenResponse.getRefreshToken() == null ){
-              System.err.println( "tokenResponse is null");
-              return;
-            }
-            UserService userService = UserServiceFactory.getUserService();
-            String userId = userService.getCurrentUser().getUserId();
-            DATA_STORE_FACTORY.getDataStore("user").set(userId+"_token", tokenResponse.getRefreshToken());
-          }
-
-          @Override
-          public void onTokenErrorResponse(Credential credential, TokenErrorResponse tokenErrorResponse) throws IOException {
-            System.err.println("OAuth2 Token Error" + tokenErrorResponse );
-            UserService userService = UserServiceFactory.getUserService();
-            String userId = userService.getCurrentUser().getUserId();
-            DATA_STORE_FACTORY.getDataStore("user").delete(userId+"_token");
-          }
-        }).setAccessType("offline").build();
-    }catch(IOException e){
-    }
-
-  }
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
@@ -135,29 +70,14 @@ public class LoginServlet extends HttpServlet {
     if (userService.isUserLoggedIn()) {
       String user = userService.getCurrentUser().getEmail();
       String userId = userService.getCurrentUser().getUserId();
-
+      CredentialServlet credentialServlet = new CredentialServlet();
 
       // If the user has already authorized, redirect to their page
-      if( isAuthorized(userId) == false ){
-        /*
-           The Authorization method will redirect to this page with GET query string
-           If this user has authorized but not been recorded, it will direct to get the access code.
-           */
-        String query = request.getQueryString();
-        if(query == null){
-          String OAuth2Url = flow.newAuthorizationUrl()
-                                .setRedirectUri(request.getRequestURL().toString())
-                                .build(); //build for string. otherwise, it'd just be object.
-          response.sendRedirect(OAuth2Url);
-          return;
-        }
-        QuerySlices slices = new QuerySlices( query );  //Should we check whether the return tokens match the format from document?
-        TokenResponse tokenResponse = requestAccessToken( request.getRequestURL().toString(), slices.get("code") );
-
-        flow.createAndStoreCredential(tokenResponse, userId);
+      if( credentialServlet.isAuthorized(userId) == false ){
+        response.sendRedirect("/credential");  
+        return;
       }
       
-      //When using response.sendRedirect, saving(?) somethings like response.getOutputStream().println(json) will make a bug like it has been committed.
       response.sendRedirect("/user-page.html?user=" + user);  
       return;
     }
@@ -166,55 +86,5 @@ public class LoginServlet extends HttpServlet {
     // which will be handled by the above if statement.
     String googleLoginUrl = userService.createLoginURL("/login");
     response.sendRedirect(googleLoginUrl);
-  }
-
-  /*
-      userId is from userService of Google Account.
-      Check if this user has authorized correctly.
-  */
-  public boolean isAuthorized( String userId ) throws IOException{
-    if(userId == null) return false;
-    Credential credential = flow.loadCredential(userId);
-    if( credential == null ) return false;  //Authorized?
-    if( credential.refreshToken() == false ) return false;  //Correctly authorized?
-    return true;
-  }
-
-  /*
-      Get Calendar for requesting calendar data of the user defined by userId.
-   */
-  public Calendar getCalendar( String userId )
-    throws IOException, FileNotFoundException{
-      Credential credential = flow.loadCredential(userId);
-      if( isAuthorized( userId ) == false ) return null;
-      return new Calendar.Builder(
-          HTTP_TRANSPORT, JSON_FACTORY, flow.loadCredential(userId))
-        .setApplicationName("CodeU team49")
-        .build();
-  }
-
-  /********Private functions********/
-
-  private TokenResponse requestAccessToken( String RedirectUri, String code ) 
-    throws TokenResponseException, IOException{
-    try {
-      return flow.newTokenRequest( code )
-                .setRedirectUri( RedirectUri )
-                .execute();
-    }catch (TokenResponseException e) {
-     //I think this error should stop this user to login until fixed.
-      if (e.getDetails() != null) {
-        System.err.println("Error: " + e.getDetails().getError());
-        if (e.getDetails().getErrorDescription() != null) {
-          System.err.println(e.getDetails().getErrorDescription());
-        }
-        if (e.getDetails().getErrorUri() != null) {
-          System.err.println(e.getDetails().getErrorUri());
-        }
-      } else {
-        System.err.println(e.getMessage());
-      }
-    }
-    return null;
   }
 }

--- a/src/main/java/com/google/codeu/servlets/LoginServlet.java
+++ b/src/main/java/com/google/codeu/servlets/LoginServlet.java
@@ -15,20 +15,96 @@
  */
 
 package com.google.codeu.servlets;
+import com.google.codeu.utils.QuerySlices;
 
 import com.google.appengine.api.users.UserService;
 import com.google.appengine.api.users.UserServiceFactory;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.Collections;
+import java.util.List;
+
+/*
+import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
+import com.google.api.client.http.javanet.NetHttpTransport;
+*/
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.http.HttpRequestInitializer;
+import com.google.api.client.http.GenericUrl;
+import com.google.api.client.auth.oauth2.BearerToken;
+import com.google.api.client.googleapis.auth.oauth2.GoogleAuthorizationCodeFlow;
+import com.google.api.client.extensions.appengine.datastore.AppEngineDataStoreFactory;
+import com.google.api.client.extensions.appengine.http.UrlFetchTransport;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.services.calendar.CalendarScopes;
+import com.google.api.client.auth.oauth2.TokenResponse;
+import com.google.api.client.auth.oauth2.TokenResponseException;
+import com.google.api.client.auth.oauth2.CredentialRefreshListener;
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleClientSecrets;
+
+
+import com.google.api.services.calendar.Calendar;
+import com.google.api.client.extensions.jetty.auth.oauth2.LocalServerReceiver;
+import com.google.api.client.extensions.java6.auth.oauth2.AuthorizationCodeInstalledApp;//why .java6?
+
 /**
  * Redirects the user to the Google login page or their page if they're already logged in.
  */
 @WebServlet("/login")
 public class LoginServlet extends HttpServlet {
+
+  private static final String CREDENTIALS_FILE_PATH = "/client_secret_Calendar_Events.json";
+  private static final AppEngineDataStoreFactory DATA_STORE_FACTORY = AppEngineDataStoreFactory.getDefaultInstance();//Not sure about whether it's global version.
+  private static final HttpTransport HTTP_TRANSPORT = new UrlFetchTransport();
+  private static final JsonFactory JSON_FACTORY = JacksonFactory.getDefaultInstance(); //JsonFactory is an abstract class, so here needs a subclass for it.
+
+  //The flow is the overall class for google authorization classes and methods.
+  private static GoogleAuthorizationCodeFlow flow = null; 
+
+  public LoginServlet() throws FileNotFoundException, IOException{
+    List<String> SCOPES = Collections.singletonList(CalendarScopes.CALENDAR);
+
+    // Load client secrets.
+    InputStream in = LoginServlet.class.getResourceAsStream(CREDENTIALS_FILE_PATH);
+    //GoogleCredential credential = GoogleCredential.fromStream(in).createScoped(SCOPES); //for service account with service account keys
+    if (in == null) {
+      throw new FileNotFoundException("Resource not found: " + CREDENTIALS_FILE_PATH);
+    }
+    GoogleClientSecrets clientSecrets = GoogleClientSecrets.load(JSON_FACTORY, new InputStreamReader(in)); //for oauth2 with client id file
+
+    flow = new GoogleAuthorizationCodeFlow.Builder( HTTP_TRANSPORT, JSON_FACTORY, clientSecrets, SCOPES)
+      .setDataStoreFactory( DATA_STORE_FACTORY )
+      /*
+      .setCredentialCreatedListener(new AuthorizationCodeFlow.CredentialCreatedListener() {
+        @Override
+        public void onCredentialCreated(Credential credential, TokenResponse tokenResponse) throws IOException {
+          DATA_STORE_FACTORY.getDataStore("user").set("id_token", tokenResponse.get("id_token").toString());
+        }
+      })
+      .addRefreshListener(new CredentialRefreshListener() {
+        @Override
+        public void onTokenResponse(Credential credential, TokenResponse tokenResponse) throws IOException {
+          DATA_STORE_FACTORY.getDataStore("user").set("id_token", tokenResponse.get("id_token").toString());
+        }
+
+        @Override
+        public void onTokenErrorResponse(Credential credential, TokenErrorResponse tokenErrorResponse) throws IOException {
+          //handle token error response
+        })
+        */
+      .setAccessType("offline").build(); //Not sure about the access type
+
+  }
+
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
     UserService userService = UserServiceFactory.getUserService();
@@ -36,7 +112,34 @@ public class LoginServlet extends HttpServlet {
     // If the user is already logged in, redirect to their page
     if (userService.isUserLoggedIn()) {
       String user = userService.getCurrentUser().getEmail();
-      response.sendRedirect("/user-page.html?user=" + user);
+      String userId = userService.getCurrentUser().getUserId();
+
+
+      // If the user has already authorized, redirect to their page
+      if( isAuthorized(userId) == false ){
+        /* 
+           The Authorization method will redirect to this page with GET query string
+           If this user has authorized but not been recorded, it will direct to get the access code.
+        */
+        String query = request.getQueryString();
+        if(query == null){
+          String OAuth2Url = flow.newAuthorizationUrl()
+                                .setRedirectUri(request.getRequestURL().toString())
+                                .build(); //build for string. otherwise, it'd just be object.
+          response.sendRedirect(OAuth2Url);
+          return;
+        }
+        QuerySlices slices = new QuerySlices( query );  //Should we check whether the return tokens match the format from document?
+        //Here, should we chatch the error from the method? or would it be thrown..?
+        TokenResponse tokenResponse = requestAccessToken( request.getRequestURL().toString(), slices.get("code") );
+
+        flow.createAndStoreCredential(tokenResponse, userId);
+        response.sendRedirect("/user-page.html?user=" + user);
+        return;
+      }
+      
+      //When using response.sendRedirect, saving(?) somethings like response.getOutputStream().println(json) will make a bug like it has been committed.
+      response.sendRedirect("/user-page.html?user=" + user);  
       return;
     }
 
@@ -44,5 +147,53 @@ public class LoginServlet extends HttpServlet {
     // which will be handled by the above if statement.
     String googleLoginUrl = userService.createLoginURL("/login");
     response.sendRedirect(googleLoginUrl);
+  }
+
+  public boolean isAuthorized( String userId ) throws IOException{
+    if (flow.loadCredential(userId) == null) return false;
+    return true;
+  }
+
+  public Calendar getCalendar( String userId )
+    throws IOException, FileNotFoundException{
+    LocalServerReceiver receiver = new LocalServerReceiver.Builder().setPort(-1).build(); //-1 for unused port
+    return new Calendar.Builder(HTTP_TRANSPORT, JSON_FACTORY,
+        new AuthorizationCodeInstalledApp(flow, receiver).authorize(userId)
+        )
+      //.setApplicationName(APPLICATION_NAME)
+      .build();
+
+  }
+
+  public HttpRequestInitializer getRequestInitializer(){
+    return flow.getRequestInitializer();
+  }
+
+  /********Private functions********/
+
+  private TokenResponse requestAccessToken( String RedirectUri, String code ) 
+    throws TokenResponseException, IOException{
+//    try {
+      return flow.newTokenRequest( code )
+                .setRedirectUri( RedirectUri )
+                .execute();
+  //  }
+    /* I think this error should stop this user to login until fixed.
+
+    catch (TokenResponseException e) {
+      if (e.getDetails() != null) {
+        System.err.println("Error: " + e.getDetails().getError());
+        if (e.getDetails().getErrorDescription() != null) {
+          System.err.println(e.getDetails().getErrorDescription());
+        }
+        if (e.getDetails().getErrorUri() != null) {
+          System.err.println(e.getDetails().getErrorUri());
+        }
+      } else {
+        System.err.println(e.getMessage());
+      }
+    }
+    return null;
+    */
   }
 }

--- a/src/main/java/com/google/codeu/servlets/LoginServlet.java
+++ b/src/main/java/com/google/codeu/servlets/LoginServlet.java
@@ -15,7 +15,6 @@
  */
 
 package com.google.codeu.servlets;
-import com.google.codeu.utils.QuerySlices;
 
 import com.google.appengine.api.users.UserService;
 import com.google.appengine.api.users.UserServiceFactory;
@@ -26,36 +25,10 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.util.Collections;
-import java.util.List;
-
-/*
-import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
-import com.google.api.client.http.javanet.NetHttpTransport;
-*/
-import com.google.api.client.http.HttpTransport;
-import com.google.api.client.http.HttpRequestInitializer;
-import com.google.api.client.http.GenericUrl;
-import com.google.api.client.auth.oauth2.BearerToken;
-import com.google.api.client.googleapis.auth.oauth2.GoogleAuthorizationCodeFlow;
-import com.google.api.client.extensions.appengine.datastore.AppEngineDataStoreFactory;
-import com.google.api.client.extensions.appengine.http.UrlFetchTransport;
-import com.google.api.client.json.JsonFactory;
-import com.google.api.client.json.jackson2.JacksonFactory;
-import com.google.api.services.calendar.CalendarScopes;
-import com.google.api.client.auth.oauth2.TokenResponse;
-import com.google.api.client.auth.oauth2.TokenErrorResponse;
-import com.google.api.client.auth.oauth2.TokenResponseException;
-import com.google.api.client.auth.oauth2.CredentialRefreshListener;
-import com.google.api.client.auth.oauth2.Credential;
-
-import com.google.api.client.googleapis.auth.oauth2.GoogleClientSecrets;
-
 import com.google.api.services.calendar.Calendar;
 
 import com.google.codeu.servlets.CredentialServlet;
+import javax.servlet.RequestDispatcher;
 /**
  * Redirects the user to the Google login page or their page if they're already logged in.
  */
@@ -74,8 +47,14 @@ public class LoginServlet extends HttpServlet {
 
       // If the user has already authorized, redirect to their page
       if( credentialServlet.isAuthorized(userId) == false ){
-        response.sendRedirect("/credential");  
-        return;
+        try{
+          RequestDispatcher dispatcher = getServletContext().getRequestDispatcher("/credential");
+          request.setAttribute("from", "/login");
+          dispatcher.forward(request, response);
+          return;
+        }catch(javax.servlet.ServletException e){
+          System.err.println( "Login forward failed: " + e);
+        }
       }
       
       response.sendRedirect("/user-page.html?user=" + user);  

--- a/src/main/java/com/google/codeu/servlets/LoginServlet.java
+++ b/src/main/java/com/google/codeu/servlets/LoginServlet.java
@@ -83,7 +83,7 @@ public class LoginServlet extends HttpServlet {
 
     flow = new GoogleAuthorizationCodeFlow.Builder( HTTP_TRANSPORT, JSON_FACTORY, clientSecrets, SCOPES)
       .setDataStoreFactory( DATA_STORE_FACTORY )
-      /*
+      /*  this part is dead. I thought it's great to use but didn't solve the error.
       .setCredentialCreatedListener(new AuthorizationCodeFlow.CredentialCreatedListener() {
         @Override
         public void onCredentialCreated(Credential credential, TokenResponse tokenResponse) throws IOException {
@@ -130,7 +130,6 @@ public class LoginServlet extends HttpServlet {
           return;
         }
         QuerySlices slices = new QuerySlices( query );  //Should we check whether the return tokens match the format from document?
-        //Here, should we chatch the error from the method? or would it be thrown..?
         TokenResponse tokenResponse = requestAccessToken( request.getRequestURL().toString(), slices.get("code") );
 
         flow.createAndStoreCredential(tokenResponse, userId);
@@ -158,9 +157,9 @@ public class LoginServlet extends HttpServlet {
     throws IOException, FileNotFoundException{
     LocalServerReceiver receiver = new LocalServerReceiver.Builder().setPort(-1).build(); //-1 for unused port
     return new Calendar.Builder(HTTP_TRANSPORT, JSON_FACTORY,
-        new AuthorizationCodeInstalledApp(flow, receiver).authorize(userId)
+        new AuthorizationCodeInstalledApp(flow, receiver).authorize(userId) //The problem
         )
-      //.setApplicationName(APPLICATION_NAME)
+      //.setApplicationName(APPLICATION_NAME) //saved until deciding whether it's necessary or ..
       .build();
 
   }
@@ -173,14 +172,12 @@ public class LoginServlet extends HttpServlet {
 
   private TokenResponse requestAccessToken( String RedirectUri, String code ) 
     throws TokenResponseException, IOException{
-//    try {
+    try {
       return flow.newTokenRequest( code )
                 .setRedirectUri( RedirectUri )
                 .execute();
-  //  }
-    /* I think this error should stop this user to login until fixed.
-
-    catch (TokenResponseException e) {
+    }catch (TokenResponseException e) {
+     //I think this error should stop this user to login until fixed.
       if (e.getDetails() != null) {
         System.err.println("Error: " + e.getDetails().getError());
         if (e.getDetails().getErrorDescription() != null) {
@@ -194,6 +191,5 @@ public class LoginServlet extends HttpServlet {
       }
     }
     return null;
-    */
   }
 }

--- a/src/main/java/com/google/codeu/utils/QuerySlices.java
+++ b/src/main/java/com/google/codeu/utils/QuerySlices.java
@@ -1,0 +1,27 @@
+/*
+ This code slice the GET query string and store them as dicstionary for further use - by method, get(String)
+ */
+package com.google.codeu.utils;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.HashMap;
+
+public class QuerySlices{ 
+  private Map<String, String> slices = new HashMap<>();
+  public QuerySlices(String query){
+    for (String param : query.split("&")) {
+        String[] entry = param.split("=");
+        if (entry.length > 1) {
+            slices.put(entry[0], entry[1]);
+        }else{
+            slices.put(entry[0], "");
+        }
+    }
+  }
+
+  public String get(String s){
+    return slices.get(s);
+  }
+
+}

--- a/src/main/java/com/google/codeu/utils/QuerySlices.java
+++ b/src/main/java/com/google/codeu/utils/QuerySlices.java
@@ -1,5 +1,7 @@
 /*
- This code slice the GET query string and store them as dicstionary for further use - by method, get(String)
+   **This should be replaced by request.getParameter(String)**
+ 
+   This code slice the GET query string and store them as dicstionary for further use - by method, get(String)
  */
 package com.google.codeu.utils;
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/20224621/59975650-172b1d00-95ed-11e9-935f-87a066dc9b59.png)

### Feedback

* The usage is on the top of the files, CredentialServlet and CalendarServlet.
* String could be cast directly into Serializable, while Serializable can't. It needs `.toString()`
* 2 types of variables in request:
  1. `parameter` - As the GET variables. Can't be revised, nor deleted.
  2. `attribute` - The variable sent from server-side, and could be an object.
* `forEach` method is faster averagely than regular iterations
* `RequestDispatcher` is mainly used for `forward` and `include`
  * `forward` is to direct the current url into another url, meanwhile contains the parameters and attributes.
  * `include` is to contain some html file in the website.
 * Other funny facts are put as comments in the code. :)

### Bug

 * Once we cleaned the datastore including the refresh token, users who have authorized before would not be able to authorized again and end in infinite redirection. Because the refresh token could be attained in the very first authorization time.
 * There're too many logs about the `refreshToken`. 