### PR TITLE
update google-api version

### DIFF
--- a/.factorypath
+++ b/.factorypath
@@ -1,5 +1,8 @@
 <factorypath>
     <factorypathentry kind="VARJAR" id="M2_REPO/javax/servlet/javax.servlet-api/3.1.0/javax.servlet-api-3.1.0.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/javax/javaee-api/8.0/javaee-api-8.0.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/com/sun/mail/javax.mail/1.6.0/javax.mail-1.6.0.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/javax/activation/activation/1.1/activation-1.1.jar" enabled="true" runInBatchMode="false"/>
     <factorypathentry kind="VARJAR" id="M2_REPO/com/google/appengine/appengine-api-1.0-sdk/1.9.76/appengine-api-1.0-sdk-1.9.76.jar" enabled="true" runInBatchMode="false"/>
     <factorypathentry kind="VARJAR" id="M2_REPO/org/jsoup/jsoup/1.8.3/jsoup-1.8.3.jar" enabled="true" runInBatchMode="false"/>
     <factorypathentry kind="VARJAR" id="M2_REPO/com/google/cloud/google-cloud-datastore/1.52.0/google-cloud-datastore-1.52.0.jar" enabled="true" runInBatchMode="false"/>
@@ -61,9 +64,8 @@
     <factorypathentry kind="VARJAR" id="M2_REPO/com/google/http-client/google-http-client-appengine/1.29.2/google-http-client-appengine-1.29.2.jar" enabled="true" runInBatchMode="false"/>
     <factorypathentry kind="VARJAR" id="M2_REPO/com/google/http-client/google-http-client-jackson2/1.29.2/google-http-client-jackson2-1.29.2.jar" enabled="true" runInBatchMode="false"/>
     <factorypathentry kind="VARJAR" id="M2_REPO/com/fasterxml/jackson/core/jackson-core/2.9.6/jackson-core-2.9.6.jar" enabled="true" runInBatchMode="false"/>
-    <factorypathentry kind="VARJAR" id="M2_REPO/com/google/apis/google-api-services-calendar/v3-rev305-1.23.0/google-api-services-calendar-v3-rev305-1.23.0.jar" enabled="true" runInBatchMode="false"/>
-    <factorypathentry kind="VARJAR" id="M2_REPO/com/google/api-client/google-api-client/1.23.0/google-api-client-1.23.0.jar" enabled="true" runInBatchMode="false"/>
-    <factorypathentry kind="VARJAR" id="M2_REPO/com/google/guava/guava-jdk5/17.0/guava-jdk5-17.0.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/com/google/apis/google-api-services-calendar/v3-rev379-1.25.0/google-api-services-calendar-v3-rev379-1.25.0.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/com/google/api-client/google-api-client/1.25.0/google-api-client-1.25.0.jar" enabled="true" runInBatchMode="false"/>
     <factorypathentry kind="VARJAR" id="M2_REPO/com/google/cloud/google-cloud-vision/1.55.0/google-cloud-vision-1.55.0.jar" enabled="true" runInBatchMode="false"/>
     <factorypathentry kind="VARJAR" id="M2_REPO/com/google/api/grpc/proto-google-cloud-vision-v1/1.48.0/proto-google-cloud-vision-v1-1.48.0.jar" enabled="true" runInBatchMode="false"/>
     <factorypathentry kind="VARJAR" id="M2_REPO/com/google/api/grpc/proto-google-cloud-vision-v1p1beta1/0.49.0/proto-google-cloud-vision-v1p1beta1-0.49.0.jar" enabled="true" runInBatchMode="false"/>

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@ limitations under the License.
     <dependency>
       <groupId>com.google.apis</groupId>
       <artifactId>google-api-services-calendar</artifactId>
-      <version>v3-rev305-1.23.0</version>
+      <version>v3-rev379-1.25.0</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Try to solve sentiment analysis not working in public url problem by updating google-api version from v3-rev305-1.23.0 to v3-rev379-1.25.0 and the guava version update automatically to 27.1.
![Screenshot from 2019-07-20 20-09-44](https://user-images.githubusercontent.com/13695825/61578497-5c7a3600-ab2a-11e9-9894-473ca2587aa7.png)
